### PR TITLE
Add cron job for Friday 3pm to ask for next week

### DIFF
--- a/desk_swap/commands/help.rb
+++ b/desk_swap/commands/help.rb
@@ -6,11 +6,11 @@ I'm your friendly desk swap 🤖, here to help.
 Avaialable Commands
 -------
 
-help               - get this helpful message
-join               - join desk swap fun :tada:
-unjoin             - opt out of desk swap fun :sad-parrot:
-setup              - update your current desk setup (monitor, standing desk and etc.)
-location           - update your desk's location
+help              - get this helpful message
+join              - join desk swap fun :tada:
+leave             - opt out of desk swap fun :sad-parrot:
+setup             - update your current desk setup (monitor, standing desk and etc.)
+location      - update your desk's location
 ```
   EOS
   def self.call(client, data, _match)

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -28,6 +28,7 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+
 ---
 apiVersion: v1
 kind: Service
@@ -38,13 +39,57 @@ metadata:
     layer: application
   name: slack-desk-swap-web
   namespace: default
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:iam::585031190124:server-certificate/2018-01-17_artsy-net-wildcard"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
 spec:
   ports:
+  - port: 443
+    protocol: TCP
+    name: https
+    targetPort: 8080
   - port: 80
     protocol: TCP
+    name: http
     targetPort: 8080
   selector:
     app: slack-desk-swap
     component: web
     layer: application
-  type: ClusterIP
+  sessionAffinity: None
+  type: LoadBalancer
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: slack-desk-swap-start-round-cron
+spec:
+  schedule: 0 15 * * 5
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: slack-desk-swap-timely-extracts-cron
+            image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/slack-desk-swap:staging
+            command: ["bundle", "exec", "rake", "desk_swap:start_today_round"]
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: slack-desk-swap-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background


### PR DESCRIPTION
This is example of running cron job with K8S, this will run Every Friday at 3pm asking about availability of desk swap for next week. 

Need to update the code to take out Sat and Sun but we can follow up on that.


Note: from K8s/hokusai perspective, once this PR is merged nothing is changed and cron job is not setup yet, for that to work we need to update deployment of the app on k8s which happens manually via:

``` 
hokusai staging update
```
I will do that manually today. 